### PR TITLE
pybind11 factories refactor

### DIFF
--- a/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/process_factory.cxx
@@ -148,8 +148,8 @@ register_process( sprokit::process::type_t const&        type,
 
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
   auto fact = vpm.add_factory( new sprokit::python_process_factory( type, // derived type name string
-                                                           typeid( object ).name(),
-                                                           wrap ) );
+                                                                    typeid( sprokit::process ).name(),
+                                                                    wrap ) );
 
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, type )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, "python-runtime" )

--- a/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline/scheduler_factory.cxx
@@ -1,5 +1,5 @@
 /*ckwg +29
- * Copyright 2011-2012 by Kitware, Inc.
+ * Copyright 2011-2017 by Kitware, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -138,8 +138,8 @@ register_scheduler( sprokit::scheduler::type_t const& type,
 
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
   auto fact = vpm.add_factory( new sprokit::python_scheduler_factory( type,
-                                                             typeid( object ).name(),
-                                                             wrap ) );
+                                                                      typeid( sprokit::scheduler ).name(),
+                                                                      wrap ) );
 
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, type )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, "python-runtime" )

--- a/sprokit/src/bindings/python/sprokit/pipeline_util/bake.cxx
+++ b/sprokit/src/bindings/python/sprokit/pipeline_util/bake.cxx
@@ -156,9 +156,9 @@ register_cluster(sprokit::cluster_info_t const& info)
 
   kwiver::vital::plugin_manager& vpm = kwiver::vital::plugin_manager::instance();
   sprokit::process::type_t derived_type = "python::";
-  auto fact = vpm.add_factory( new sprokit::process_factory( derived_type + type, // derived type name string
-                                                             type, // name of the cluster/process
-                                                             ctor ) );
+  auto fact = vpm.add_factory( new sprokit::cpp_process_factory( derived_type + type, // derived type name string
+                                                                 type, // name of the cluster/process
+                                                                 ctor ) );
 
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, type )
     .add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, "python-runtime-cluster" )

--- a/sprokit/src/processes/clusters/registration.cxx
+++ b/sprokit/src/processes/clusters/registration.cxx
@@ -155,7 +155,7 @@ register_factories( kwiver::vital::plugin_loader& vpm )
         try
         {
           // Add cluster to process registry with a specific factory function
-          auto fact = vpm.add_factory( new sprokit::process_factory( type, typeid( sprokit::process ).name(), ctor ) );
+          auto fact = vpm.add_factory( new sprokit::cpp_process_factory( type, typeid( sprokit::process ).name(), ctor ) );
           fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, description );
 
           // Indicate this is a cluster and add source file name

--- a/sprokit/src/schedulers/examples/registration.cxx
+++ b/sprokit/src/schedulers/examples/registration.cxx
@@ -55,8 +55,10 @@ register_factories( kwiver::vital::plugin_loader& vpm )
   auto fact = vpm.ADD_SCHEDULER( sprokit::thread_pool_scheduler );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_NAME, "thread_pool" );
   fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_MODULE_NAME, module_name );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION, "Use a pool of threads to step processes" );
-  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "1.0" );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_DESCRIPTION,
+                       "Use a pool of threads to step processes. "
+                       "This example is not functional." );
+  fact->add_attribute( kwiver::vital::plugin_factory::PLUGIN_VERSION, "0.1" );
 
   sprokit::mark_scheduler_module_as_loaded( vpm, module_name );
 }

--- a/sprokit/src/sprokit/pipeline/process_factory.h
+++ b/sprokit/src/sprokit/pipeline/process_factory.h
@@ -102,13 +102,36 @@ public:
    *
    * @param type Type name of the process
    * @param itype Type name of interface type.
-   * @param factory The Factory function
    */
   process_factory( const std::string& type,
-                   const std::string& itype,
-                   process_factory_func_t factory );
+                   const std::string& itype );
 
-  virtual ~process_factory();
+  virtual ~process_factory() = default;
+
+  virtual sprokit::process_t create_object(kwiver::vital::config_block_sptr const& config) = 0;
+};
+
+
+// ----------------------------------------------------------------------------
+class SPROKIT_PIPELINE_EXPORT cpp_process_factory
+: public sprokit::process_factory
+{
+public:
+  /**
+   * @brief CTOR for factory object
+   *
+   * This CTOR also takes a factory function so it can support
+   * creating processes and clusters.
+   *
+   * @param type Type name of the process
+   * @param itype Type name of interface type.
+   * @param factory The Factory function
+   */
+  cpp_process_factory( const std::string& type,
+                       const std::string& itype,
+                       process_factory_func_t factory );
+
+  virtual ~cpp_process_factory() = default;
 
   virtual sprokit::process_t create_object(kwiver::vital::config_block_sptr const& config);
 
@@ -167,16 +190,17 @@ kwiver::vital::plugin_factory_vector_t const& get_process_list();
 //
 // Convenience macro for adding processes
 //
-#define ADD_PROCESS( proc_type )                          \
-  add_factory( new sprokit::process_factory( typeid( proc_type ).name(), \
-                                             typeid( sprokit::process ).name(), \
-                                             sprokit::create_new_process< proc_type > ) )
+#define ADD_PROCESS( proc_type )                                        \
+  add_factory( new sprokit::cpp_process_factory( typeid( proc_type ).name(), \
+                                                 typeid( sprokit::process ).name(), \
+                                                 sprokit::create_new_process< proc_type > ) )
 
 #ifdef SPROKIT_ENABLE_PYTHON
+
 typedef std::function< pybind11::object( kwiver::vital::config_block_sptr const& config ) > py_process_factory_func_t;
 
 class SPROKIT_PIPELINE_EXPORT python_process_factory
-: public kwiver::vital::plugin_factory
+  : public sprokit::process_factory
 {
   /**
    * @brief CTOR for factory object
@@ -201,10 +225,6 @@ private:
   py_process_factory_func_t m_factory;
 };
 
-SPROKIT_PIPELINE_EXPORT
-sprokit::process_t create_py_process(const sprokit::process::type_t&        type,
-                                     const sprokit::process::name_t&        name,
-                                     const kwiver::vital::config_block_sptr config = kwiver::vital::config_block::empty_config() );
 #endif
 
 } // end namespace

--- a/sprokit/src/sprokit/pipeline/scheduler_factory.h
+++ b/sprokit/src/sprokit/pipeline/scheduler_factory.h
@@ -103,28 +103,42 @@ public:
    *
    * @param type Type name of the scheduler
    * @param itype Type name of interface type.
-   * @param factory The Factory function
    */
   scheduler_factory( const std::string&       type,
-                     const std::string&       itype,
-                     scheduler_factory_func_t factory )
-    : plugin_factory( itype )
-    , m_factory( factory )
-  {
-    this->add_attribute( CONCRETE_TYPE, type)
-      .add_attribute( PLUGIN_FACTORY_TYPE, typeid( *this ).name() )
-      .add_attribute( PLUGIN_CATEGORY, "scheduler" );
-  }
+                     const std::string&       itype );
 
   virtual ~scheduler_factory() = default;
 
   virtual sprokit::scheduler_t create_object( pipeline_t const& pipe,
-                                              kwiver::vital::config_block_sptr const& config )
-  {
-    // Call sprokit factory function. Need to use this factory
-    // function approach to handle clusters transparently.
-    return m_factory( pipe, config );
-  }
+                                              kwiver::vital::config_block_sptr const& config ) = 0;
+};
+
+
+// ----------------------------------------------------------------------------
+class SPROKIT_PIPELINE_EXPORT cpp_scheduler_factory
+: public scheduler_factory
+{
+public:
+  static scheduler::type_t const default_type;
+
+  /**
+   * @brief CTOR for factory object
+   *
+   * This CTOR also takes a factory function so it can support
+   * creating schedulers.
+   *
+   * @param type Type name of the scheduler
+   * @param itype Type name of interface type.
+   * @param factory The Factory function
+   */
+  cpp_scheduler_factory( const std::string&       type,
+                         const std::string&       itype,
+                         scheduler_factory_func_t factory );
+
+  virtual ~cpp_scheduler_factory() = default;
+
+  virtual sprokit::scheduler_t create_object( pipeline_t const& pipe,
+                                              kwiver::vital::config_block_sptr const& config );
 
 private:
   scheduler_factory_func_t m_factory;
@@ -173,17 +187,18 @@ bool is_scheduler_module_loaded( kwiver::vital::plugin_loader& vpl,
 //
 // Convenience macro for adding schedulers
 //
-#define ADD_SCHEDULER( type )                                         \
-  add_factory( new sprokit::scheduler_factory( typeid( type ).name(),   \
-                                               typeid( sprokit::scheduler ).name(), \
-                                               sprokit::create_new_scheduler< type > ) )
+#define ADD_SCHEDULER( type )                                           \
+  add_factory( new sprokit::cpp_scheduler_factory( typeid( type ).name(), \
+                                                   typeid( sprokit::scheduler ).name(), \
+                                                   sprokit::create_new_scheduler< type > ) )
 
 #ifdef SPROKIT_ENABLE_PYTHON
+
 typedef std::function< pybind11::object( sprokit::pipeline_t const& pipe,
                                kwiver::vital::config_block_sptr const& config ) > py_scheduler_factory_func_t;
 
 class SPROKIT_PIPELINE_EXPORT python_scheduler_factory
-: public kwiver::vital::plugin_factory
+: public scheduler_factory
 {
 
   public:
@@ -192,7 +207,7 @@ class SPROKIT_PIPELINE_EXPORT python_scheduler_factory
                             const std::string& itype,
                             py_scheduler_factory_func_t factory );
 
-  virtual ~python_scheduler_factory();
+  virtual ~python_scheduler_factory() = default;
 
   virtual scheduler_t create_object(sprokit::pipeline_t const& pipe,
                                     kwiver::vital::config_block_sptr const& config);
@@ -201,11 +216,6 @@ private:
   py_scheduler_factory_func_t m_factory;
 };
 
-SPROKIT_PIPELINE_EXPORT
-scheduler_t
-create_py_scheduler( const sprokit::scheduler::type_t&      name,
-                     const sprokit::pipeline_t&             pipe,
-                     const kwiver::vital::config_block_sptr config = kwiver::vital::config_block::empty_config() );
 #endif
 
 } // end namespace


### PR DESCRIPTION
Refactored process and scheduler factories.
    
    Created an abstract base class and derived tow concrete factory classes.
    One for cpp {processes,schedulers} and one for python. The details
    of converting python object into a process shared_ptr are delegated
    to the derived classes.
    
    This approach solves the problem in the plugin_explorer where there
    was an additional factory type for the pybind11::object that was not
    handled.